### PR TITLE
Clear CAN Frame buffer with 0x55 instead of 0x00

### DIFF
--- a/src/lib_obdii.c
+++ b/src/lib_obdii.c
@@ -475,7 +475,7 @@ static void clear_obdii_packets( POBDII_PACKET_MANAGER dev )
 
     for( uint8_t index = 0; index < OBDII_MAX_FRAMES; index++)
     {
-        memset(dev->frame[index].buf, 0, OBDII_DLC);
+        memset(dev->frame[index].buf, 0x55, OBDII_DLC);
     }
 }
 


### PR DESCRIPTION
Nice work @MattKai45! Been following you on your FB page for a while, and was excited to see your code go open source.

I think it's best practice to send "pad" DLC bytes as 0x55 (for requests, and responses 0xAA). With the bits "ping-pong'ing" there's no need at the CAN layer to introduce stuff bits (like you can get with 0x00's being sent). Looks like you're requesting all of your PIDs in a single request, so this won't be game changing, but why not.